### PR TITLE
Add options to option flow

### DIFF
--- a/custom_components/ha_opcua_discovery/__init__.py
+++ b/custom_components/ha_opcua_discovery/__init__.py
@@ -61,9 +61,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hub = OpcuaHub(
         hub_name=hub_id,
         hub_url=entry.options.get(CONF_HUB_URL, entry.data.get(CONF_HUB_URL)),
-        root_node_id=entry.options.get(CONF_HUB_ROOT_NODE, entry.data.get(CONF_HUB_ROOT_NODE)),
-        username=entry.options.get(CONF_HUB_USERNAME, entry.data.get(CONF_HUB_USERNAME)),
-        password=entry.options.get(CONF_HUB_PASSWORD, entry.data.get(CONF_HUB_PASSWORD)),
+        root_node_id=entry.options.get(
+            CONF_HUB_ROOT_NODE, entry.data.get(CONF_HUB_ROOT_NODE)
+        ),
+        username=entry.options.get(
+            CONF_HUB_USERNAME, entry.data.get(CONF_HUB_USERNAME)
+        ),
+        password=entry.options.get(
+            CONF_HUB_PASSWORD, entry.data.get(CONF_HUB_PASSWORD)
+        ),
     )
 
     coordinator = AsyncuaCoordinator(

--- a/custom_components/ha_opcua_discovery/config_flow.py
+++ b/custom_components/ha_opcua_discovery/config_flow.py
@@ -61,7 +61,7 @@ class AsyncUAConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_USERNAME): str,
                 vol.Optional(CONF_PASSWORD): str,
                 vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): int,
-                vol.Optional(CONF_HUB_ROOT_NODE, default="ns=2;i=1"): str,
+                vol.Required(CONF_HUB_ROOT_NODE, default="ns=2;i=1"): str,
             }
         )
 
@@ -82,15 +82,19 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:
+            url = user_input[CONF_URL]
+            username = user_input.get(CONF_USERNAME)
+            password = user_input.get(CONF_PASSWORD)
             root_node = user_input.get(CONF_HUB_ROOT_NODE, "").strip()
-            scan_interval = user_input.get(
-                CONF_HUB_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-            )
+            scan_interval = user_input.get(CONF_HUB_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
 
             # Update the options by creating the entry
             result = self.async_create_entry(
                 title="",
                 data={
+                    CONF_HUB_URL: url,
+                    CONF_HUB_USERNAME: username,
+                    CONF_HUB_PASSWORD: password,
                     CONF_HUB_SCAN_INTERVAL: scan_interval,
                     CONF_HUB_ROOT_NODE: root_node,
                 },
@@ -102,6 +106,25 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
             )
 
             return result
+
+        current_hub_url = self.config_entry.options.get(
+            CONF_HUB_URL,
+            self.config_entry.data.get(CONF_HUB_URL),
+        )
+
+        current_hub_username = self.config_entry.options.get(
+            CONF_HUB_USERNAME,
+            self.config_entry.data.get(CONF_HUB_USERNAME),
+        )
+        if current_hub_username is None: # We dont want to have a None value else it will generate an error
+            current_hub_username = ""
+
+        current_hub_password = self.config_entry.options.get(
+            CONF_HUB_PASSWORD,
+            self.config_entry.data.get(CONF_HUB_PASSWORD),
+        )
+        if current_hub_password is None:
+            current_hub_password = ""
 
         current_scan_interval = self.config_entry.options.get(
             CONF_HUB_SCAN_INTERVAL,
@@ -117,10 +140,11 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(
-                        CONF_HUB_SCAN_INTERVAL, default=current_scan_interval
-                    ): int,
-                    vol.Optional(CONF_HUB_ROOT_NODE, default=current_root_node): str,
+                    vol.Required(CONF_HUB_URL, default=current_hub_url): str,
+                    vol.Optional(CONF_HUB_USERNAME, default=current_hub_username): str,
+                    vol.Optional(CONF_HUB_PASSWORD, default=current_hub_password): str,
+                    vol.Optional(CONF_HUB_SCAN_INTERVAL, default=current_scan_interval): int,
+                    vol.Required(CONF_HUB_ROOT_NODE, default=current_root_node): str,
                 }
             ),
         )

--- a/custom_components/ha_opcua_discovery/config_flow.py
+++ b/custom_components/ha_opcua_discovery/config_flow.py
@@ -86,7 +86,9 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
             username = user_input.get(CONF_USERNAME)
             password = user_input.get(CONF_PASSWORD)
             root_node = user_input.get(CONF_HUB_ROOT_NODE, "").strip()
-            scan_interval = user_input.get(CONF_HUB_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+            scan_interval = user_input.get(
+                CONF_HUB_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            )
 
             # Update the options by creating the entry
             result = self.async_create_entry(
@@ -116,7 +118,9 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
             CONF_HUB_USERNAME,
             self.config_entry.data.get(CONF_HUB_USERNAME),
         )
-        if current_hub_username is None: # We dont want to have a None value else it will generate an error
+        if (
+            current_hub_username is None
+        ):  # We dont want to have a None value else it will generate an error
             current_hub_username = ""
 
         current_hub_password = self.config_entry.options.get(
@@ -143,7 +147,9 @@ class AsyncUAOptionsFlow(config_entries.OptionsFlow):
                     vol.Required(CONF_HUB_URL, default=current_hub_url): str,
                     vol.Optional(CONF_HUB_USERNAME, default=current_hub_username): str,
                     vol.Optional(CONF_HUB_PASSWORD, default=current_hub_password): str,
-                    vol.Optional(CONF_HUB_SCAN_INTERVAL, default=current_scan_interval): int,
+                    vol.Optional(
+                        CONF_HUB_SCAN_INTERVAL, default=current_scan_interval
+                    ): int,
                     vol.Required(CONF_HUB_ROOT_NODE, default=current_root_node): str,
                 }
             ),

--- a/custom_components/ha_opcua_discovery/manifest.json
+++ b/custom_components/ha_opcua_discovery/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "",
   "requirements": ["asyncua==1.0.2"],
-  "version": "v1.0.1",
+  "version": "v1.0.2",
   "platforms": ["sensor", "switch"],
   "quality_scale": "bronze"
 }


### PR DESCRIPTION
- Added more options to the option flow 
- Made the node_id field required
- Fixed the integration not detecting that the OPC-UA server is misconfigured on hub creation/reloading/option change